### PR TITLE
Allow wallets to fit playing cards

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -41,7 +41,8 @@
 		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/armor/tag,
 		/obj/item/clothing/ring,
-		/obj/item/weapon/passport
+		/obj/item/weapon/passport,
+		/obj/item/weapon/hand
 	)
 	slot_flags = SLOT_ID
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Playing cards and their children (Cardemon) can fit in wallets.